### PR TITLE
Replaced references

### DIFF
--- a/Documents/OVERVIEW.md
+++ b/Documents/OVERVIEW.md
@@ -2,7 +2,7 @@
 
 The **STMicroelectronics NUCLEO-L476RG Board Support Pack (BSP)**:
 
-- Contains examples in *csolution format* for usage with the [CMSIS-Toolbox](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/README.md) and the  [VS Code CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution) extension.
+- Contains examples in *csolution format* for usage with the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/) and the  [VS Code CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution) extension.
 - Requires the [Device Family Pack (DFP) for the STM32L4 series](https://www.keil.arm.com/packs/stm32l4xx_dfp-keil).
 - Is configured with [STM32CubeMX](https://www.st.com/en/development-tools/stm32cubemx.html) for the Arm Compiler 6 (MDK).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is the development repository for the **STMicroelectronics NUCLEO-L476RG Board Support Pack (BSP)** - a CMSIS software pack that is designed to work with all compiler toolchains (Arm Compiler, GCC, IAR, LLVM). It is released as [CMSIS software pack](https://www.keil.arm.com/packs/nucleo-l476rg_bsp-keil) and therefore accessible by CMSIS-Pack enabled software development tools.
 
-This BSP uses the generator integration of the [CMSIS-Toolbox to Configure STM32 Devices with CubeMX](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/CubeMX.md) that is also supported in µVision 5.40 and higher.
+This BSP uses the generator integration of the [CMSIS-Toolbox to Configure STM32 Devices with CubeMX](https://open-cmsis-pack.github.io/cmsis-toolbox/CubeMX/) that is also supported in µVision 5.40 and higher.
 
 ## Repository top-level structure
 
@@ -21,7 +21,7 @@ Directory                   | Description
 
 ## Using the development repository
 
-This development repository can be used in a local directory and [mapped as software pack](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/build-tools.md#install-a-repository) using for example `cpackget` with:
+This development repository can be used in a local directory and [mapped as software pack](https://open-cmsis-pack.github.io/cmsis-toolbox/build-tools#install-a-repository) using for example `cpackget` with:
 
     cpackget add <path>/Keil.NUCLEO-L476RG_BSP.pdsc
 


### PR DESCRIPTION
Replaced references to https://github.com/Open-CMSIS-Pack/cmsis-toolbox/... to https://open-cmsis-pack.github.io/cmsis-toolbox/ a.o
[Issue 248](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/248)